### PR TITLE
Cache Supabase clients for HMR

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -84,13 +84,20 @@ const getSupabaseClient = () => {
 export const supabase = getSupabaseClient()
 
 // For server-side operations that require elevated permissions
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key'
+const isProductionWithoutServiceRole = process.env.NODE_ENV === 'production' && serviceRoleKey === 'placeholder-service-role-key' && supabaseUrl !== 'https://placeholder.supabase.co'
+
+if (isProductionWithoutServiceRole && typeof window === 'undefined') {
+  console.error('CRITICAL: Supabase service role key not configured in production!')
+}
+
 const getSupabaseAdminClient = () => {
   if (!globalForSupabase._supabaseAdminClient) {
     globalForSupabase._supabaseAdminClient = shouldUseMockClient
       ? createMockClient()
       : createClient<Database>(
           supabaseUrl,
-          process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key',
+          serviceRoleKey,
           {
             auth: {
               autoRefreshToken: false,


### PR DESCRIPTION
## Summary
- cache Supabase user and admin clients on the global object to survive HMR/import cycles
- add a unique auth storageKey to avoid collisions during strict-mode rendering
- ensure the admin client is only created server-side and reuse a mock client otherwise

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943300c4ba08328b457cdda2ffc5bfd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database error messages with clearer, user-friendly guidance.

* **Chores**
  * Refactored database client initialization for improved performance and reliability.

* **Reliability**
  * Added runtime checks and logging to detect and alert on production authentication misconfigurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->