### PR TITLE
Add Vercel analytics integration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { QueryProvider } from "@/providers/query-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { VercelAnalytics } from "@/components/vercel-analytics";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -32,6 +33,7 @@ export default function RootLayout({
         <QueryProvider>
           {children}
           <Toaster />
+          <VercelAnalytics />
         </QueryProvider>
       </body>
     </html>

--- a/src/components/vercel-analytics.tsx
+++ b/src/components/vercel-analytics.tsx
@@ -1,0 +1,38 @@
+// This is a client component because it wraps next/script.
+"use client";
+
+import Script from "next/script";
+
+const VERCEL_ANALYTICS_SRC = "https://va.vercel-scripts.com/v1/script.js";
+const VERCEL_ANALYTICS_DEBUG_SRC =
+  "https://va.vercel-scripts.com/v1/script.debug.js";
+
+type VercelAnalyticsProps = {
+  /**
+   * Forces the use of the debug script instead of the production one.
+   * When undefined, the script choice follows the current NODE_ENV.
+   */
+  debug?: boolean;
+};
+
+export function VercelAnalytics({ debug }: VercelAnalyticsProps) {
+  const token = process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ID;
+
+  if (!token) {
+    return null;
+  }
+
+  const isDebug = debug ?? process.env.NODE_ENV !== "production";
+  const src = isDebug ? VERCEL_ANALYTICS_DEBUG_SRC : VERCEL_ANALYTICS_SRC;
+
+  return (
+    <Script
+      id="vercel-analytics"
+      src={src}
+      strategy="afterInteractive"
+      data-token={token}
+      data-sdkn="nextjs"
+      data-sdkv="manual"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable VercelAnalytics client component that loads the Vercel analytics script when a public token is available
- include the analytics component in the root layout so tracking runs across the app

## Testing
- npm run lint
- npm run build (fails in this environment because Geist fonts cannot be fetched from Google Fonts)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694225bdf9248328b4d540cea2039f4b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated analytics tracking to monitor application performance and user engagement metrics throughout the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->