### PR TITLE
Remove view dashboard button from My Groups card

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -173,11 +173,6 @@ export function DashboardContent({ user, profile, onSignOut }: DashboardContentP
                   {groups.length > 3 && (
                     <p className="text-xs text-slate-600">+{groups.length - 3} more groups</p>
                   )}
-                  <Link href="/">
-                    <Button variant="secondary" className="w-full">
-                      View Dashboard
-                    </Button>
-                  </Link>
                 </div>
               )}
             </CardContent>


### PR DESCRIPTION
## Summary
- remove the View Dashboard action from the My Groups card on the home dashboard

## Testing
- npm run lint *(fails: missing dev dependency eslint-config-next in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944cc032e988328933c3fe241582cb5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed "View Dashboard" action button from the My Groups card.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->