### PR TITLE
Add see all button to dashboard My Groups card

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -38,6 +38,7 @@ export function DashboardContent({ user, profile, onSignOut }: DashboardContentP
     },
     enabled: Boolean(user),
   })
+  const [showAllGroups, setShowAllGroups] = useState(false)
 
   const displayName = [
     profile?.first_name ?? user?.user_metadata?.first_name,
@@ -204,7 +205,7 @@ export function DashboardContent({ user, profile, onSignOut }: DashboardContentP
                 </div>
               ) : (
                 <div className="space-y-3">
-                  {groups.slice(0, 3).map((group: DashboardGroup) => (
+                  {(showAllGroups ? groups : groups.slice(0, 3)).map((group: DashboardGroup) => (
                     <Link
                       key={group.id}
                       href={`/groups/${group.id}`}
@@ -225,8 +226,20 @@ export function DashboardContent({ user, profile, onSignOut }: DashboardContentP
                       </div>
                     </Link>
                   ))}
-                  {groups.length > 3 && (
+                  {groups.length > 3 && !showAllGroups && (
                     <p className="text-xs text-slate-600">+{groups.length - 3} more groups</p>
+                  )}
+                  {groups.length > 3 && (
+                    <div className="pt-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full text-indigo-700 hover:bg-indigo-50"
+                        onClick={() => setShowAllGroups((prev) => !prev)}
+                      >
+                        {showAllGroups ? 'Show less' : 'See all'}
+                      </Button>
+                    </div>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add a see all/show less toggle to the My Groups card so users can expand the full list of their groups
- keep the extra group count visible only while collapsed and retain existing loading/empty states

## Testing
- npm run lint *(fails: missing dependency eslint-config-next in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d92456088328943d6e22b054d59d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to expand and collapse the dashboard group list, allowing users to view either the first three groups or all available groups.
  * Added a See all / Show less toggle button to switch between these views.
  * Updated the plus indicator to display only when additional groups are available and the list is not expanded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->