### PR TITLE
Improve auth form keyboard navigation

### DIFF
--- a/src/components/auth/__tests__/auth-form.test.tsx
+++ b/src/components/auth/__tests__/auth-form.test.tsx
@@ -101,7 +101,8 @@ describe('AuthForm', () => {
       render(<AuthForm mode="signup" />)
       
       expect(screen.getByText('Sign up to create and manage contact groups')).toBeInTheDocument()
-      expect(screen.getByLabelText('Full Name')).toBeInTheDocument()
+      expect(screen.getByLabelText('First Name')).toBeInTheDocument()
+      expect(screen.getByLabelText('Last Name')).toBeInTheDocument()
       expect(screen.getByLabelText('Email')).toBeInTheDocument()
       expect(screen.getByLabelText('Password')).toBeInTheDocument()
       expect(screen.getByLabelText(/Phone Number/)).toBeInTheDocument()
@@ -114,7 +115,8 @@ describe('AuthForm', () => {
       
       render(<AuthForm mode="signup" />)
       
-      await user.type(screen.getByLabelText('Full Name'), 'John Doe')
+      await user.type(screen.getByLabelText('First Name'), 'John')
+      await user.type(screen.getByLabelText('Last Name'), 'Doe')
       await user.type(screen.getByLabelText('Email'), 'john@example.com')
       await user.type(screen.getByLabelText('Password'), 'password123')
       await user.type(screen.getByLabelText(/Phone Number/), '+1234567890')
@@ -140,7 +142,7 @@ describe('AuthForm', () => {
       await user.click(screen.getByRole('button', { name: 'Create Account' }))
       
       await waitFor(() => {
-        expect(screen.getByText('Full name is required')).toBeInTheDocument()
+        expect(screen.getByText('First name is required')).toBeInTheDocument()
       })
     })
 
@@ -149,7 +151,8 @@ describe('AuthForm', () => {
       
       render(<AuthForm mode="signup" />)
       
-      await user.type(screen.getByLabelText('Full Name'), 'John Doe')
+      await user.type(screen.getByLabelText('First Name'), 'John')
+      await user.type(screen.getByLabelText('Last Name'), 'Doe')
       await user.type(screen.getByLabelText('Email'), 'test@example.com')
       await user.type(screen.getByLabelText('Password'), '123')
       await user.click(screen.getByRole('button', { name: 'Create Account' }))
@@ -157,6 +160,31 @@ describe('AuthForm', () => {
       await waitFor(() => {
         expect(screen.getByText('Password must be at least 8 characters')).toBeInTheDocument()
       })
+    })
+
+    it('advances focus with Enter key until the last field', async () => {
+      const user = userEvent.setup()
+
+      render(<AuthForm mode=\"signup\" />)
+
+      const firstName = screen.getByLabelText('First Name')
+      const lastName = screen.getByLabelText('Last Name')
+      const email = screen.getByLabelText('Email')
+      const password = screen.getByLabelText('Password')
+      const phone = screen.getByLabelText(/Phone Number/)
+
+      firstName.focus()
+      await user.keyboard('{Enter}')
+      expect(lastName).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(email).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(password).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(phone).toHaveFocus()
     })
   })
 

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -26,6 +26,9 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
   const { signIn, signUp } = useAuth()
 
   const isSignUp = authMode === 'signup'
+
+  const signInFieldOrder: Array<keyof SignInFormData> = ['email', 'password']
+  const signUpFieldOrder: Array<keyof SignUpFormData> = ['first_name', 'last_name', 'email', 'password', 'phone']
   
   const signInForm = useForm<SignInFormData>({
     resolver: zodResolver(signInSchema),
@@ -104,6 +107,23 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
     setIsLoading(false)
   }
 
+  const focusNextField = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    field: keyof SignInFormData | keyof SignUpFormData
+  ) => {
+    if (event.key !== 'Enter') return
+
+    const form = isSignUp ? signUpForm : signInForm
+    const fieldOrder = isSignUp ? signUpFieldOrder : signInFieldOrder
+    const currentIndex = fieldOrder.indexOf(field as never)
+    const nextField = fieldOrder[currentIndex + 1]
+
+    if (nextField) {
+      event.preventDefault()
+      form.setFocus(nextField as never)
+    }
+  }
+
   // Show 2FA verification if needed
   if (show2FA) {
     return (
@@ -141,7 +161,10 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
                   id="first_name"
                   type="text"
                   placeholder="Enter your first name"
-                  {...signUpForm.register('first_name')}
+                  enterKeyHint="next"
+                  {...signUpForm.register('first_name', {
+                    onKeyDown: (event) => focusNextField(event, 'first_name')
+                  })}
                   className={signUpForm.formState.errors.first_name ? 'border-red-500' : ''}
                 />
                 {signUpForm.formState.errors.first_name && (
@@ -157,7 +180,10 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
                   id="last_name"
                   type="text"
                   placeholder="Enter your last name"
-                  {...signUpForm.register('last_name')}
+                  enterKeyHint="next"
+                  {...signUpForm.register('last_name', {
+                    onKeyDown: (event) => focusNextField(event, 'last_name')
+                  })}
                   className={signUpForm.formState.errors.last_name ? 'border-red-500' : ''}
                 />
                 {signUpForm.formState.errors.last_name && (
@@ -175,7 +201,15 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
               id="email"
               type="email"
               placeholder="Enter your email"
-              {...(isSignUp ? signUpForm.register('email') : signInForm.register('email'))}
+              enterKeyHint="next"
+              {...(isSignUp
+                ? signUpForm.register('email', {
+                    onKeyDown: (event) => focusNextField(event, 'email')
+                  })
+                : signInForm.register('email', {
+                    onKeyDown: (event) => focusNextField(event, 'email')
+                  })
+              )}
               className={currentForm.formState.errors.email ? 'border-red-500' : ''}
             />
             {currentForm.formState.errors.email && (
@@ -192,7 +226,15 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
                 id="password"
                 type={showPassword ? 'text' : 'password'}
                 placeholder={isSignUp ? 'Create a password (min 8 characters)' : 'Enter your password'}
-                {...(isSignUp ? signUpForm.register('password') : signInForm.register('password'))}
+                enterKeyHint={isSignUp ? 'next' : 'go'}
+                {...(isSignUp
+                  ? signUpForm.register('password', {
+                      onKeyDown: (event) => focusNextField(event, 'password')
+                    })
+                  : signInForm.register('password', {
+                      onKeyDown: (event) => focusNextField(event, 'password')
+                    })
+                )}
                 className={currentForm.formState.errors.password ? 'border-red-500 pr-10' : 'pr-10'}
               />
               <button
@@ -217,7 +259,10 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
                 id="phone"
                 type="tel"
                 placeholder="Enter your phone number"
-                {...signUpForm.register('phone')}
+                enterKeyHint="go"
+                {...signUpForm.register('phone', {
+                  onKeyDown: (event) => focusNextField(event, 'phone')
+                })}
                 className={signUpForm.formState.errors.phone ? 'border-red-500' : ''}
               />
               {signUpForm.formState.errors.phone && (


### PR DESCRIPTION
## Summary
- add ordered enter-key navigation so auth form fields advance on mobile until the final input
- set enterKeyHint values for each auth input to better control keyboard actions
- update auth form tests to reflect split name fields and new keyboard behavior

## Testing
- npm test -- --runInBand auth-form *(fails: vitest unavailable because npm install was blocked by 403 from registry.npmjs.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d96f67ec8328a6ec48737e99b14b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signup form now displays separate First Name and Last Name fields instead of a single Full Name field.
  * Added keyboard navigation: users can press Enter to move between form fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->