### PR TITLE
Rename "Text Me" button to "Get Contacts"

### DIFF
--- a/src/components/groups/contact-export.tsx
+++ b/src/components/groups/contact-export.tsx
@@ -332,7 +332,7 @@ export function ContactExport({ groupId, groupName, layout = 'card' }: ContactEx
           )
         )}
 
-        {/* Text Me + export-all dropdown (split button) */}
+        {/* Get Contacts + export-all dropdown (split button) */}
         <div className="flex">
           <Button
             onClick={() => setShowSmsInput(!showSmsInput)}
@@ -342,7 +342,7 @@ export function ContactExport({ groupId, groupName, layout = 'card' }: ContactEx
             className="rounded-r-none border-r-0"
           >
             <Smartphone className="h-4 w-4" />
-            Text Me
+            Get Contacts
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -253,7 +253,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
 
   const memberCount = members?.length ?? 0
 
-  // Header with Select All + Text Me
+  // Header with Select All + Get Contacts
   const headerContent = (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -274,7 +274,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                 className="rounded-r-none border-r-0"
               >
                 {isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Smartphone className="h-4 w-4" />}
-                Text Me
+                Get Contacts
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>


### PR DESCRIPTION
Clarifies the action for users — the button sends group contacts to
their phone, so "Get Contacts" communicates the outcome more directly.