### PR TITLE
fix: use min-h-dvh instead of min-h-screen to prevent spurious mobile scroll

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -27,7 +27,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
       </div>
     )
@@ -40,7 +40,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   // Show retry UI when profile failed to load
   if (profileFetchFailed) {
     return (
-      <div className="flex min-h-screen bg-background items-center justify-center flex-col gap-4">
+      <div className="flex min-h-dvh bg-background items-center justify-center flex-col gap-4">
         <p className="text-muted-foreground">Unable to load your profile. Please try again.</p>
         <Button onClick={retryProfile}>
           <RefreshCw className="h-4 w-4" />
@@ -51,7 +51,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <div className="fixed top-0 left-0 right-0 z-50 bg-background">
         <AppHeader />
       </div>

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -41,7 +41,7 @@ export default function ProfileSettingsPage() {
 
   if (loading || !user) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin" />
       </div>
     )

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -67,7 +67,7 @@ export default function AuthCallbackPage() {
   }, [router])
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-dvh flex items-center justify-center">
       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
     </div>
   )

--- a/src/app/auth/check-email/page.tsx
+++ b/src/app/auth/check-email/page.tsx
@@ -11,7 +11,7 @@ export default async function CheckEmailPage({ searchParams }: CheckEmailPagePro
   const email = params?.email ? decodeURIComponent(params.email) : null
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex min-h-dvh items-center justify-center px-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1 text-center">
           <CardTitle className="text-2xl font-bold">Check your email</CardTitle>

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -21,7 +21,7 @@ function AuthContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-dvh flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     )
@@ -32,7 +32,7 @@ function AuthContent() {
   }
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+    <div className="min-h-dvh bg-background flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <AuthForm
           mode={mode}
@@ -47,7 +47,7 @@ function AuthContent() {
 export default function AuthPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-dvh flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     }>

--- a/src/app/group/[token]/join/page.tsx
+++ b/src/app/group/[token]/join/page.tsx
@@ -118,7 +118,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
   // Loading state
   if (groupLoading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="min-h-dvh bg-background flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     )
@@ -127,7 +127,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
   // Error states
   if (groupError || !group) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="text-center text-destructive">Group Not Found</CardTitle>
@@ -150,7 +150,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
 
   if (group.is_closed) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="text-center">Group Closed</CardTitle>
@@ -173,7 +173,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
 
   if (group.archived_at) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="text-center">Group Not Available</CardTitle>
@@ -197,8 +197,8 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
   // OTP step
   if (step === 'otp' && formData) {
     return (
-      <div className="min-h-screen bg-background">
-        <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-12">
+      <div className="min-h-dvh bg-background">
+        <main className="mx-auto flex min-h-dvh max-w-lg flex-col justify-center px-4 py-12">
           <OTPVerifyForm
             phone={formData.phone}
             onVerified={handleOtpVerified}
@@ -212,7 +212,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
   // Password step
   if (step === 'password') {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -254,7 +254,7 @@ export default function GroupJoinPage({ params }: JoinPageProps) {
 
   // Form step (default)
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+    <div className="min-h-dvh bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">

--- a/src/app/onboarding/phone/page.tsx
+++ b/src/app/onboarding/phone/page.tsx
@@ -38,8 +38,8 @@ export default function OnboardingPhonePage() {
   if (loading || user) return null
 
   return (
-    <div className="min-h-screen bg-background">
-      <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-12">
+    <div className="min-h-dvh bg-background">
+      <main className="mx-auto flex min-h-dvh max-w-lg flex-col justify-center px-4 py-12">
         <header className="mb-10 text-center">
           <h1 className="font-display text-4xl font-bold leading-tight sm:text-5xl">
             Welcome to Bubbles

--- a/src/app/onboarding/profile/page.tsx
+++ b/src/app/onboarding/profile/page.tsx
@@ -183,14 +183,14 @@ export default function OnboardingProfilePage() {
 
   if (loading || !user) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <main className="mx-auto max-w-lg px-4 py-12">
         <header className="mb-8 text-center">
           <h1 className="font-display text-3xl font-bold leading-tight sm:text-4xl">

--- a/src/app/onboarding/verify/page.tsx
+++ b/src/app/onboarding/verify/page.tsx
@@ -45,15 +45,15 @@ function VerifyContent() {
   // Show spinner while waiting for profile to load after auth
   if (user && !loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-12">
+    <div className="min-h-dvh bg-background">
+      <main className="mx-auto flex min-h-dvh max-w-lg flex-col justify-center px-4 py-12">
         <OTPVerifyForm
           phone={phone}
           onVerified={handleVerified}
@@ -68,7 +68,7 @@ export default function OnboardingVerifyPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center">
+        <div className="flex min-h-dvh items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,8 +9,8 @@ export default async function Home() {
   const showCopy = await showLandingPageCopy()
 
   return (
-    <div className="min-h-screen bg-background">
-      <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-12">
+    <div className="min-h-dvh bg-background">
+      <main className="mx-auto flex min-h-dvh max-w-lg flex-col justify-center px-4 py-12">
         <header className="mb-10 text-center">
           <h1 className="font-display text-4xl font-bold leading-tight sm:text-5xl">
             Bubbles

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata = {
 
 export default function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <main className="mx-auto max-w-2xl animate-fade-up-in px-4 py-12 sm:px-6">
         <header className="mb-10">
           <p className="font-label mb-2 text-xs uppercase tracking-widest text-muted-foreground">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -6,7 +6,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <main className="mx-auto max-w-2xl animate-fade-up-in px-4 py-12 sm:px-6">
         <header className="mb-10">
           <p className="font-label mb-2 text-xs uppercase tracking-widest text-muted-foreground">

--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -37,7 +37,7 @@ export function ProtectedRoute({
 
   if (loading) {
     return fallback || (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-dvh flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
           <p className="text-muted-foreground">Loading...</p>

--- a/src/components/groups/group-detail.tsx
+++ b/src/components/groups/group-detail.tsx
@@ -121,7 +121,7 @@ export function GroupDetail({ token, showSuccessToast, showQrCode = true, showCu
 
   if (groupLoading) {
     return (
-      <div className="flex min-h-screen flex-col">
+      <div className="flex min-h-dvh flex-col">
         {/* Orange hero skeleton — matches QrCodeHero h-[520px] exactly */}
         <div className="flex h-[520px] flex-col items-center justify-between bg-[#E8622A] px-6 py-10">
           <div className="space-y-2 text-center">
@@ -167,7 +167,7 @@ export function GroupDetail({ token, showSuccessToast, showQrCode = true, showCu
   if (!group) return null
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-dvh flex-col">
       {/* Archived banner */}
       {group.archived_at && isOwner && (
         <div className="flex items-center justify-between bg-[#F0E8D9] px-4 py-2.5">


### PR DESCRIPTION
Tailwind's min-h-screen resolves to min-height: 100vh, which on mobile
browsers references the large viewport (URL bar hidden). When the URL bar
is showing, the visible viewport is smaller than 100vh, so any page using
min-h-screen ended up taller than the visible area and scrolled even with
minimal content — e.g. /dashboard scrolled with just 1 group. Swapping to
min-h-dvh tracks the visible viewport dynamically and collapses to 100vh
on desktop, so there's no visual change where the bug wasn't present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated layout height behavior across all pages and components to use dynamic viewport measurements, improving compatibility with browser UI and safe-area considerations on various devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->