### PR TITLE
Extract vCard generation to shared library with UID/REV support

### DIFF
--- a/src/app/api/groups/[groupId]/contacts.vcf/route.ts
+++ b/src/app/api/groups/[groupId]/contacts.vcf/route.ts
@@ -1,52 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
-
-interface GroupMember {
-  id: string
-  first_name: string
-  last_name: string
-  email?: string | null
-  phone?: string
-  avatar_url?: string | null
-}
-
-const escapeVCardValue = (value?: string | null) => {
-  if (!value) return ''
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .trim()
-}
-
-function generateVCard(member: GroupMember, groupName: string): string {
-  const firstName = member.first_name?.trim() || ''
-  const lastName = member.last_name?.trim() || ''
-  const fullName = [firstName, lastName].filter(Boolean).join(' ') || member.email || 'Bubbles Member'
-  const givenName = firstName || fullName
-
-  const vcard = [
-    'BEGIN:VCARD',
-    'VERSION:3.0',
-    `N:${escapeVCardValue(lastName)};${escapeVCardValue(givenName)};;;`,
-    `FN:${escapeVCardValue(fullName)}`,
-  ]
-
-  if (member.email) vcard.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(member.email)}`)
-  if (member.phone) {
-    vcard.push(`TEL;TYPE=CELL:${escapeVCardValue(member.phone)}`)
-  }
-
-  if (member.avatar_url) {
-    vcard.push(`PHOTO;VALUE=URI:${escapeVCardValue(member.avatar_url)}`)
-  }
-
-  vcard.push(`ORG:${escapeVCardValue(groupName)} | bubbles.fyi`)
-  vcard.push(`NOTE:${escapeVCardValue(`Member of ${groupName} group from bubbles.fyi`)}`)
-  vcard.push('END:VCARD')
-  return vcard.join('\r\n')
-}
+import { generateBulkVCard, type VCardMember } from '@/lib/vcard'
 
 export async function GET(
   request: NextRequest,
@@ -96,8 +50,7 @@ export async function GET(
     return NextResponse.json({ error: 'No members found' }, { status: 404 })
   }
 
-  const vcards = members.map((m) => generateVCard(m as GroupMember, group.name))
-  const vcfContent = vcards.join('\r\n\r\n') + '\r\n'
+  const vcfContent = generateBulkVCard(members as VCardMember[], group.name)
   const filename = `${group.name.replace(/[^a-zA-Z0-9]/g, '_')}_contacts.vcf`
 
   return new NextResponse(vcfContent, {

--- a/src/app/api/sms/send-contacts/route.ts
+++ b/src/app/api/sms/send-contacts/route.ts
@@ -1,53 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import twilio from 'twilio'
 import { supabaseAdmin } from '@/lib/supabase'
-
-interface GroupMember {
-  id: string
-  first_name: string
-  last_name: string
-  email?: string | null
-  phone?: string
-  avatar_url?: string | null
-}
-
-const escapeVCardValue = (value?: string | null) => {
-  if (!value) return ''
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .trim()
-}
-
-function generateVCard(member: GroupMember, groupName: string): string {
-  const firstName = member.first_name?.trim() || ''
-  const lastName = member.last_name?.trim() || ''
-  const fullName = [firstName, lastName].filter(Boolean).join(' ') || member.email || 'Bubbles Member'
-  const givenName = firstName || fullName
-
-  const vcard = [
-    'BEGIN:VCARD',
-    'VERSION:3.0',
-    `N:${escapeVCardValue(lastName)};${escapeVCardValue(givenName)};;;`,
-    `FN:${escapeVCardValue(fullName)}`,
-  ]
-
-  if (member.email) vcard.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(member.email)}`)
-  if (member.phone) {
-    vcard.push(`TEL;TYPE=CELL:${escapeVCardValue(member.phone)}`)
-  }
-
-  if (member.avatar_url) {
-    vcard.push(`PHOTO;VALUE=URI:${escapeVCardValue(member.avatar_url)}`)
-  }
-
-  vcard.push(`ORG:${escapeVCardValue(groupName)} | bubbles.fyi`)
-  vcard.push(`NOTE:${escapeVCardValue(`Member of ${groupName} group from bubbles.fyi`)}`)
-  vcard.push('END:VCARD')
-  return vcard.join('\r\n')
-}
+import { generateMemberVCard, formatVCardRev, type VCardMember } from '@/lib/vcard'
 
 export async function POST(request: NextRequest) {
   const accountSid = process.env.TWILIO_ACCOUNT_SID
@@ -98,14 +52,22 @@ export async function POST(request: NextRequest) {
   if (memberError || !memberData || memberData.length === 0) {
     return NextResponse.json({ error: 'No members found' }, { status: 404 })
   }
-  const members = memberData as unknown as GroupMember[]
+  const members = memberData as unknown as VCardMember[]
 
-  // Generate .vcf content — lead with a Bubbles contact card so users save the sending number
+  // Use one REV instant across every card in this export so the output
+  // is internally consistent.
+  const exportedAt = new Date()
+
+  // Generate .vcf content — lead with a Bubbles contact card so users save
+  // the sending number. A hard-coded UID lets iOS dedupe re-sends of the
+  // sender card, matching the member cards' dedup behavior.
   const bubblesVCard = [
     'BEGIN:VCARD',
     'VERSION:3.0',
     'N:;Bubbles;;;',
     'FN:Bubbles',
+    'UID:urn:bubbles:service:sender',
+    `REV:${formatVCardRev(exportedAt)}`,
     `TEL;TYPE=CELL:${fromNumber}`,
     'URL:https://bubbles.fyi',
     'ORG:bubbles.fyi',
@@ -113,7 +75,9 @@ export async function POST(request: NextRequest) {
     'END:VCARD',
   ].join('\r\n')
 
-  const memberVCards = members.map((m) => generateVCard(m, fetchedGroupName)).join('\r\n\r\n')
+  const memberVCards = members
+    .map((m) => generateMemberVCard(m, fetchedGroupName, exportedAt))
+    .join('\r\n\r\n')
   const vcfContent = bubblesVCard + '\r\n\r\n' + memberVCards + '\r\n'
   const filename = `${groupId}/${Date.now()}.vcf`
 

--- a/src/components/groups/__tests__/contact-export.test.tsx
+++ b/src/components/groups/__tests__/contact-export.test.tsx
@@ -70,18 +70,27 @@ afterEach(() => {
 // ─── generateBulkVCard ────────────────────────────────────────────────────────
 
 describe('generateBulkVCard', () => {
-  it('joins two vCards with \\r\\n\\r\\n separator', async () => {
-    const user = userEvent.setup()
-    // Capture blob parts by intercepting the Blob constructor
-    let capturedContent = ''
+  // Intercept Blob construction so we can inspect the vCard text the
+  // component feeds to the desktop downloader.
+  const captureBlobContent = (): { getContent: () => string; restore: () => void } => {
+    let captured = ''
     const OrigBlob = global.Blob
     global.Blob = class MockBlob extends OrigBlob {
       constructor(parts: BlobPart[], options?: BlobPropertyBag) {
         super(parts, options)
-        capturedContent = parts.map(String).join('')
+        captured = parts.map(String).join('')
       }
     } as typeof Blob
+    return {
+      getContent: () => captured,
+      restore: () => {
+        global.Blob = OrigBlob
+      },
+    }
+  }
 
+  const triggerExportAll = async () => {
+    const user = userEvent.setup()
     URL.createObjectURL = vi.fn(() => 'blob:mock')
     URL.revokeObjectURL = vi.fn()
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
@@ -94,11 +103,45 @@ describe('generateBulkVCard', () => {
     fireEvent.click(screen.getByText(/Export All/))
 
     await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled())
+  }
 
-    expect((capturedContent.match(/BEGIN:VCARD/g) || []).length).toBe(2)
-    expect(capturedContent).toMatch(/END:VCARD\r\n\r\nBEGIN:VCARD/)
+  it('joins two vCards with \\r\\n\\r\\n separator', async () => {
+    const blob = captureBlobContent()
+    await triggerExportAll()
 
-    global.Blob = OrigBlob
+    const content = blob.getContent()
+    expect((content.match(/BEGIN:VCARD/g) || []).length).toBe(2)
+    expect(content).toMatch(/END:VCARD\r\n\r\nBEGIN:VCARD/)
+
+    blob.restore()
+  })
+
+  it('emits a stable UID:urn:uuid:<member.id> for every member card', async () => {
+    const blob = captureBlobContent()
+    await triggerExportAll()
+
+    const content = blob.getContent()
+    // One UID per member, matching the member.id values from the mock.
+    expect(content).toMatch(/UID:urn:uuid:1\r\n/)
+    expect(content).toMatch(/UID:urn:uuid:2\r\n/)
+    // Exactly two UID lines total.
+    expect((content.match(/\r\nUID:/g) || []).length).toBe(2)
+
+    blob.restore()
+  })
+
+  it('emits a REV line in ISO-8601 UTC form (no milliseconds)', async () => {
+    const blob = captureBlobContent()
+    await triggerExportAll()
+
+    const content = blob.getContent()
+    const revs = content.match(/\r\nREV:[^\r]+/g) || []
+    expect(revs.length).toBe(2)
+    for (const rev of revs) {
+      expect(rev).toMatch(/^\r\nREV:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+    }
+
+    blob.restore()
   })
 })
 

--- a/src/components/groups/contact-export.tsx
+++ b/src/components/groups/contact-export.tsx
@@ -16,6 +16,10 @@ import {
 import { getGroupMembers } from '@/lib/database'
 import { toast } from 'sonner'
 import { getDisplayName, extractNames } from '@/lib/name-utils'
+import {
+  generateMemberVCard,
+  generateBulkVCard as generateBulkVCardBase,
+} from '@/lib/vcard'
 
 interface GroupMember {
   id: string
@@ -33,16 +37,6 @@ interface ContactExportProps {
   groupId: string
   groupName: string
   layout?: 'card' | 'embedded'
-}
-
-const escapeVCardValue = (value?: string | null) => {
-  if (!value) return ''
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .trim()
 }
 
 export function ContactExport({ groupId, groupName, layout = 'card' }: ContactExportProps) {
@@ -63,39 +57,12 @@ export function ContactExport({ groupId, groupName, layout = 'card' }: ContactEx
   const disableBulkActions = !members || members.length === 0
 
   // Generate vCard content for a single member
-  const generateVCard = (member: GroupMember): string => {
-    const { firstName, lastName } = extractNames(member)
-    const fullName = getDisplayName(member) || member.email || 'Bubbles Member'
-    const givenName = firstName || fullName
-
-    const vcard = [
-      'BEGIN:VCARD',
-      'VERSION:3.0',
-      `N:${escapeVCardValue(lastName)};${escapeVCardValue(givenName)};;;`,
-      `FN:${escapeVCardValue(fullName)}`,
-    ]
-
-    if (member.email) vcard.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(member.email)}`)
-    if (member.phone) {
-      vcard.push(`TEL;TYPE=CELL:${escapeVCardValue(member.phone)}`)
-    }
-
-    if (member.avatar_url) {
-      vcard.push(`PHOTO;VALUE=URI:${escapeVCardValue(member.avatar_url)}`)
-    }
-
-    // Add organization/note to indicate the group
-    vcard.push(`ORG:${escapeVCardValue(groupName)} | bubbles.fyi`)
-    vcard.push(`NOTE:${escapeVCardValue(`Member of ${groupName} group from bubbles.fyi`)}`)
-
-    vcard.push('END:VCARD')
-    return vcard.join('\r\n')
-  }
+  const generateVCard = (member: GroupMember): string =>
+    generateMemberVCard(member, groupName)
 
   // Generate combined vCard content for multiple members
-  const generateBulkVCard = (memberList: GroupMember[]): string => {
-    return `${memberList.map(generateVCard).join('\r\n\r\n')}\r\n`
-  }
+  const generateBulkVCard = (memberList: GroupMember[]): string =>
+    generateBulkVCardBase(memberList, groupName)
 
   const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/i.test(navigator.userAgent)
 

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/database'
 import { toast } from 'sonner'
 import { getDisplayName, getInitials, extractNames } from '@/lib/name-utils'
+import { generateBulkVCard } from '@/lib/vcard'
 import { useAuth } from '@/hooks/use-auth'
 
 interface GroupMember {
@@ -48,16 +49,6 @@ interface MemberListProps {
   isOwner: boolean
   onExportContacts?: () => void
   layout?: 'card' | 'embedded'
-}
-
-const escapeVCardValue = (value?: string | null) => {
-  if (!value) return ''
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .trim()
 }
 
 export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: MemberListProps) {
@@ -155,29 +146,6 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     }
   }
 
-  // vCard generation
-  const generateVCard = (member: GroupMember): string => {
-    const { firstName, lastName } = extractNames(member)
-    const fullName = getDisplayName(member) || member.email || 'Bubbles Member'
-    const givenName = firstName || fullName
-    const vcard = [
-      'BEGIN:VCARD',
-      'VERSION:3.0',
-      `N:${escapeVCardValue(lastName)};${escapeVCardValue(givenName)};;;`,
-      `FN:${escapeVCardValue(fullName)}`,
-    ]
-    if (member.email) vcard.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(member.email)}`)
-    if (member.phone) vcard.push(`TEL;TYPE=CELL:${escapeVCardValue(member.phone)}`)
-    if (member.avatar_url) vcard.push(`PHOTO;VALUE=URI:${escapeVCardValue(member.avatar_url)}`)
-    vcard.push(`ORG:${escapeVCardValue(groupName)} | bubbles.fyi`)
-    vcard.push(`NOTE:${escapeVCardValue(`Member of ${groupName} group from bubbles.fyi`)}`)
-    vcard.push('END:VCARD')
-    return vcard.join('\r\n')
-  }
-
-  const generateBulkVCard = (memberList: GroupMember[]): string =>
-    `${memberList.map(generateVCard).join('\r\n\r\n')}\r\n`
-
   const getSingleContactFilename = (member: GroupMember) => {
     const { firstName, lastName } = extractNames(member)
     return `${firstName}_${lastName}`.replace(/[^a-zA-Z0-9_]/g, '_') + '.vcf'
@@ -219,7 +187,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     if (!members || members.length === 0) return toast.error('No members to export')
     try {
       setIsExporting(true)
-      const content = generateBulkVCard(members)
+      const content = generateBulkVCard(members, groupName)
       const filename = `${groupName.replace(/[^a-zA-Z0-9]/g, '_')}_all_contacts.vcf`
       if (via === 'share') await downloadViaShare(content, filename)
       else if (via === 'direct') downloadViaDataUri(content)

--- a/src/lib/__tests__/vcard.test.ts
+++ b/src/lib/__tests__/vcard.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import {
+  escapeVCardValue,
+  formatVCardRev,
+  generateMemberVCard,
+  generateBulkVCard,
+} from '../vcard'
+
+const FIXED_REV = new Date('2026-04-10T12:34:56.789Z')
+
+const member = {
+  id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  first_name: 'Jane',
+  last_name: "O'Brien",
+  email: 'jane@example.com',
+  phone: '+1-555-0100',
+  avatar_url: 'https://example.com/avatar.jpg',
+}
+
+describe('escapeVCardValue', () => {
+  it('escapes backslash, newline, semicolon, and comma', () => {
+    expect(escapeVCardValue('a\\b\nc;d,e')).toBe('a\\\\b\\nc\\;d\\,e')
+  })
+
+  it('returns empty string for null/undefined', () => {
+    expect(escapeVCardValue(null)).toBe('')
+    expect(escapeVCardValue(undefined)).toBe('')
+  })
+})
+
+describe('formatVCardRev', () => {
+  it('produces ISO-8601 UTC with no milliseconds', () => {
+    expect(formatVCardRev(FIXED_REV)).toBe('2026-04-10T12:34:56Z')
+  })
+})
+
+describe('generateMemberVCard', () => {
+  it('emits BEGIN/END, VERSION 3.0, and all core fields', () => {
+    const vcard = generateMemberVCard(member, 'Test Group', FIXED_REV)
+    expect(vcard.startsWith('BEGIN:VCARD\r\n')).toBe(true)
+    expect(vcard.endsWith('\r\nEND:VCARD')).toBe(true)
+    expect(vcard).toContain('VERSION:3.0')
+    // Apostrophes are not escaped in vCard 3.0 (only \\, LF, ;, and , are).
+    expect(vcard).toContain("FN:Jane O'Brien")
+    expect(vcard).toContain("N:O'Brien;Jane;;;")
+    expect(vcard).toContain('EMAIL;TYPE=INTERNET:jane@example.com')
+    expect(vcard).toContain('TEL;TYPE=CELL:+1-555-0100')
+    expect(vcard).toContain('PHOTO;VALUE=URI:https://example.com/avatar.jpg')
+    expect(vcard).toContain('ORG:Test Group | bubbles.fyi')
+    expect(vcard).toContain('NOTE:Member of Test Group group from bubbles.fyi')
+  })
+
+  it('emits a stable UID:urn:uuid:<member.id>', () => {
+    const vcard = generateMemberVCard(member, 'Test Group', FIXED_REV)
+    expect(vcard).toContain(`UID:urn:uuid:${member.id}`)
+    // UID must be stable across repeated calls with the same member.
+    const again = generateMemberVCard(member, 'Test Group', FIXED_REV)
+    const uidLine = (s: string) => s.match(/UID:[^\r\n]+/)?.[0]
+    expect(uidLine(vcard)).toBe(uidLine(again))
+  })
+
+  it('emits a REV timestamp in ISO-8601 UTC form', () => {
+    const vcard = generateMemberVCard(member, 'Test Group', FIXED_REV)
+    expect(vcard).toContain('REV:2026-04-10T12:34:56Z')
+  })
+
+  it('places UID and REV immediately after FN', () => {
+    const vcard = generateMemberVCard(member, 'Test Group', FIXED_REV)
+    const lines = vcard.split('\r\n')
+    const fnIdx = lines.findIndex((l) => l.startsWith('FN:'))
+    expect(lines[fnIdx + 1]).toMatch(/^UID:urn:uuid:/)
+    expect(lines[fnIdx + 2]).toMatch(/^REV:/)
+  })
+
+  it('omits optional fields when missing', () => {
+    const bare = {
+      id: 'bare-id',
+      first_name: 'Bob',
+      last_name: 'Smith',
+      email: null,
+      phone: null,
+      avatar_url: null,
+    }
+    const vcard = generateMemberVCard(bare, 'Test Group', FIXED_REV)
+    expect(vcard).not.toContain('EMAIL')
+    expect(vcard).not.toContain('TEL')
+    expect(vcard).not.toContain('PHOTO')
+    // UID and REV should still be present.
+    expect(vcard).toContain('UID:urn:uuid:bare-id')
+    expect(vcard).toContain('REV:2026-04-10T12:34:56Z')
+  })
+
+  it('falls back to email as FN when name is empty', () => {
+    const nameless = {
+      id: 'no-name',
+      first_name: '',
+      last_name: '',
+      email: 'no-name@example.com',
+    }
+    const vcard = generateMemberVCard(nameless, 'Test Group', FIXED_REV)
+    expect(vcard).toContain('FN:no-name@example.com')
+  })
+})
+
+describe('generateBulkVCard', () => {
+  const other = {
+    id: '22222222-2222-2222-2222-222222222222',
+    first_name: 'Bob',
+    last_name: 'Smith',
+    email: 'bob@example.com',
+  }
+
+  it('joins member vCards with CRLF CRLF and terminates with CRLF', () => {
+    const bulk = generateBulkVCard([member, other], 'Test Group', FIXED_REV)
+    expect((bulk.match(/BEGIN:VCARD/g) || []).length).toBe(2)
+    expect(bulk).toMatch(/END:VCARD\r\n\r\nBEGIN:VCARD/)
+    expect(bulk.endsWith('\r\n')).toBe(true)
+  })
+
+  it('uses the same REV instant for every card in a bulk export', () => {
+    const bulk = generateBulkVCard([member, other], 'Test Group', FIXED_REV)
+    const revs = bulk.match(/REV:[^\r\n]+/g) || []
+    expect(revs.length).toBe(2)
+    expect(new Set(revs).size).toBe(1)
+  })
+
+  it('emits distinct UIDs for distinct members', () => {
+    const bulk = generateBulkVCard([member, other], 'Test Group', FIXED_REV)
+    expect(bulk).toContain(`UID:urn:uuid:${member.id}`)
+    expect(bulk).toContain(`UID:urn:uuid:${other.id}`)
+  })
+})

--- a/src/lib/vcard.ts
+++ b/src/lib/vcard.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared vCard 3.0 generator for group members.
+ *
+ * Critical: every member vCard carries a stable `UID:urn:uuid:<member.id>`
+ * so iOS's Contacts app can deduplicate on re-import. Without UID, iOS
+ * falls back to fuzzy matching and creates fresh duplicates on every
+ * bulk .vcf import.
+ */
+
+import { extractNames, getDisplayName } from '@/lib/name-utils'
+
+export interface VCardMember {
+  id: string
+  first_name?: string | null
+  last_name?: string | null
+  email?: string | null
+  phone?: string | null
+  avatar_url?: string | null
+}
+
+export const escapeVCardValue = (value?: string | null): string => {
+  if (!value) return ''
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .trim()
+}
+
+/**
+ * Formats a Date as a vCard REV timestamp.
+ * iOS accepts the extended ISO-8601 form `YYYY-MM-DDTHH:MM:SSZ`
+ * (no milliseconds).
+ */
+export const formatVCardRev = (date: Date = new Date()): string => {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+/**
+ * Generate a single-member vCard 3.0 string.
+ *
+ * @param member  Member fields (id is required and becomes the UID).
+ * @param groupName  Group name, used for ORG/NOTE lines.
+ * @param rev  Optional REV timestamp; defaults to now.
+ */
+export function generateMemberVCard(
+  member: VCardMember,
+  groupName: string,
+  rev: Date = new Date()
+): string {
+  const { firstName, lastName } = extractNames({
+    first_name: member.first_name ?? '',
+    last_name: member.last_name ?? '',
+  })
+  const fullName =
+    getDisplayName({
+      first_name: member.first_name ?? '',
+      last_name: member.last_name ?? '',
+    }) ||
+    member.email ||
+    'Bubbles Member'
+  const givenName = firstName || fullName
+
+  const lines = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `N:${escapeVCardValue(lastName)};${escapeVCardValue(givenName)};;;`,
+    `FN:${escapeVCardValue(fullName)}`,
+    `UID:urn:uuid:${member.id}`,
+    `REV:${formatVCardRev(rev)}`,
+  ]
+
+  if (member.email) lines.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(member.email)}`)
+  if (member.phone) lines.push(`TEL;TYPE=CELL:${escapeVCardValue(member.phone)}`)
+  if (member.avatar_url) lines.push(`PHOTO;VALUE=URI:${escapeVCardValue(member.avatar_url)}`)
+
+  lines.push(`ORG:${escapeVCardValue(groupName)} | bubbles.fyi`)
+  lines.push(`NOTE:${escapeVCardValue(`Member of ${groupName} group from bubbles.fyi`)}`)
+  lines.push('END:VCARD')
+
+  return lines.join('\r\n')
+}
+
+/**
+ * Generate a multi-member vCard string (concatenated with CRLF-CRLF and
+ * terminated with a trailing CRLF, matching the prior inline behavior).
+ *
+ * All members share a single `rev` instant so a bulk export is
+ * internally consistent.
+ */
+export function generateBulkVCard(
+  members: VCardMember[],
+  groupName: string,
+  rev: Date = new Date()
+): string {
+  return (
+    members.map((m) => generateMemberVCard(m, groupName, rev)).join('\r\n\r\n') + '\r\n'
+  )
+}


### PR DESCRIPTION
## Summary
Consolidates duplicated vCard generation logic across three endpoints/components into a shared `src/lib/vcard.ts` library. Adds stable `UID:urn:uuid:<member.id>` and `REV` timestamp fields to all member vCards to enable proper deduplication in iOS Contacts on re-import.

## Key Changes
- **New library**: Created `src/lib/vcard.ts` with:
  - `escapeVCardValue()` – vCard 3.0 value escaping (backslash, newline, semicolon, comma)
  - `formatVCardRev()` – ISO-8601 UTC timestamp formatting (no milliseconds)
  - `generateMemberVCard()` – Single member vCard with stable UID and REV
  - `generateBulkVCard()` – Multi-member vCard concatenation with shared REV instant
  - `VCardMember` interface for type safety

- **Removed duplication**: Eliminated identical `escapeVCardValue()` and vCard generation logic from:
  - `src/app/api/sms/send-contacts/route.ts`
  - `src/app/api/groups/[groupId]/contacts.vcf/route.ts`
  - `src/components/groups/contact-export.tsx`
  - `src/components/groups/member-list.tsx`

- **iOS deduplication**: Added `UID:urn:uuid:<member.id>` to every member card so iOS can deduplicate on re-import (previously relied on fuzzy matching, causing duplicates). Also added `UID:urn:bubbles:service:sender` to the Bubbles sender card.

- **Consistent timestamps**: All member vCards in a bulk export now share a single `REV` instant for internal consistency.

- **Comprehensive tests**: Added 132 lines of test coverage in `src/lib/__tests__/vcard.test.ts` validating escaping, formatting, UID stability, field ordering, and bulk generation.

- **Updated component tests**: Enhanced `src/components/groups/__tests__/contact-export.test.tsx` to verify UID and REV emission in exported vCards.

## Implementation Details
- Uses existing `extractNames()` and `getDisplayName()` from `name-utils` for consistent name handling
- Maintains vCard 3.0 format compatibility (apostrophes not escaped per spec)
- Falls back to email or "Bubbles Member" when name is empty
- Optional fields (email, phone, avatar) omitted when null/undefined
- All endpoints now use the shared library, reducing maintenance burden

https://claude.ai/code/session_01DzX6Y2SUfKDPSXFWLnGZvV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated duplicate vCard generation logic across contact export features for consistency and reliability.
  * Enhanced vCard exports with stable unique identifiers and standardized revision timestamps for improved compatibility with contact applications.

* **Tests**
  * Added comprehensive test coverage for vCard generation utilities to ensure consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->