### PR TITLE
Add multi-select and per-member contact export to MemberList

### DIFF
--- a/src/app/api/sms/send-contacts/route.ts
+++ b/src/app/api/sms/send-contacts/route.ts
@@ -62,15 +62,29 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { to, groupId, groupName } = body as {
+  const { to, groupId, groupName, memberIds } = body as {
     to: string
     groupId: string
     groupName?: string
+    memberIds?: string[]
   }
 
   if (!to || !groupId) {
     return NextResponse.json(
       { error: 'Missing required fields: to (phone number), groupId' },
+      { status: 400 }
+    )
+  }
+
+  // Optional subset filter. If the client sent memberIds at all, require at
+  // least one valid id so a client bug can't silently fall through to "send
+  // everyone" when a filtered send was intended.
+  const filterIds = Array.isArray(memberIds)
+    ? memberIds.filter((id) => typeof id === 'string' && id.length > 0)
+    : undefined
+  if (memberIds !== undefined && (!filterIds || filterIds.length === 0)) {
+    return NextResponse.json(
+      { error: 'memberIds must contain at least one id' },
       { status: 400 }
     )
   }
@@ -87,12 +101,19 @@ export async function POST(request: NextRequest) {
   }
   const fetchedGroupName = (groupData as { name: string }).name
 
-  // Fetch active members
-  const { data: memberData, error: memberError } = await supabaseAdmin
+  // Fetch active members (optionally filtered to a selected subset). The
+  // .eq('group_id', ...) + .is('departed_at', null) stay AND-ed with the id
+  // filter, which is what prevents cross-group id injection — passing ids
+  // from another group will simply hit the "No members found" path below.
+  let memberQuery = supabaseAdmin
     .from('group_memberships')
     .select('id, first_name, last_name, email, phone, avatar_url')
     .eq('group_id', groupId)
     .is('departed_at', null)
+  if (filterIds && filterIds.length > 0) {
+    memberQuery = memberQuery.in('id', filterIds)
+  }
+  const { data: memberData, error: memberError } = await memberQuery
     .order('joined_at', { ascending: true })
 
   if (memberError || !memberData || memberData.length === 0) {

--- a/src/components/groups/__tests__/member-list.test.tsx
+++ b/src/components/groups/__tests__/member-list.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { render } from '@/test/utils'
 import { MemberList } from '../member-list'
 import * as database from '@/lib/database'
@@ -47,6 +47,7 @@ const mockMembers = [
     last_name: 'Doe',
     email: 'john@example.com',
     phone: '+1234567890',
+    avatar_url: null,
     notifications_enabled: true,
     joined_at: '2024-01-01T00:00:00Z',
     is_owner: true
@@ -57,6 +58,7 @@ const mockMembers = [
     last_name: 'Smith',
     email: 'jane@example.com',
     phone: undefined,
+    avatar_url: null,
     notifications_enabled: false,
     joined_at: '2024-01-02T00:00:00Z',
     is_owner: false
@@ -159,15 +161,243 @@ describe('MemberList', () => {
     })
 
     render(
-      <MemberList 
-        groupId="test-group" 
-        groupName="Test Group" 
-        isOwner={true} 
+      <MemberList
+        groupId="test-group"
+        groupName="Test Group"
+        isOwner={true}
       />
     )
 
     await waitFor(() => {
       expect(screen.getAllByText('Failed to load members')).toHaveLength(2)
     })
+  })
+})
+
+// Tests for multi-select + per-member "get contact" button.
+// Runs against the mobile layout (md:hidden) since jsdom has no viewport.
+describe('MemberList — contact selection', () => {
+  const originalUserAgent = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+  const originalCreateObjectURL = typeof URL !== 'undefined' ? URL.createObjectURL : undefined
+  const originalRevokeObjectURL = typeof URL !== 'undefined' ? URL.revokeObjectURL : undefined
+
+  const setUserAgent = (value: string) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Non-iOS by default so the get-contact button uses the blob download path.
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36')
+    mockGetGroupMembers.mockResolvedValue({ data: mockMembers, error: null })
+    if (typeof URL !== 'undefined') {
+      URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+      URL.revokeObjectURL = vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent)
+    if (typeof URL !== 'undefined') {
+      if (originalCreateObjectURL) URL.createObjectURL = originalCreateObjectURL
+      if (originalRevokeObjectURL) URL.revokeObjectURL = originalRevokeObjectURL
+    }
+    vi.restoreAllMocks()
+  })
+
+  const renderList = () =>
+    render(
+      <MemberList groupId="test-group" groupName="Test Group" isOwner={true} />
+    )
+
+  const waitForMembers = async () => {
+    // Mobile + desktop layouts both render in jsdom (media queries don't apply)
+    // so the same member name appears twice; use getAllByText to accept either.
+    await waitFor(() => {
+      expect(screen.getAllByText('John Doe').length).toBeGreaterThan(0)
+    })
+  }
+
+  // Same reason — each member has a mobile row checkbox AND a desktop table row
+  // checkbox. We only need to click one of them to exercise the state.
+  const getRowCheckbox = (name: string) =>
+    screen.getAllByRole('checkbox', { name: `Select ${name}` })[0]
+
+  it('renders a select-all checkbox and one checkbox per member (mobile)', async () => {
+    renderList()
+    await waitForMembers()
+
+    // Mobile: select-all + 2 rows = 3 mobile checkboxes. Desktop table duplicates
+    // these, so in jsdom we'll actually see 6 checkboxes (md:hidden does not
+    // remove them). Just sanity check the labeled ones.
+    expect(
+      screen.getAllByRole('checkbox', { name: 'Select all members' }).length
+    ).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getAllByRole('checkbox', { name: 'Select John Doe' }).length
+    ).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getAllByRole('checkbox', { name: 'Select Jane Smith' }).length
+    ).toBeGreaterThanOrEqual(1)
+  })
+
+  it('toggling a member updates the Get Contacts button label with a count', async () => {
+    renderList()
+    await waitForMembers()
+
+    // Baseline: no count
+    expect(
+      screen.getByRole('button', { name: /^Get Contacts$/ })
+    ).toBeInTheDocument()
+
+    fireEvent.click(getRowCheckbox('Jane Smith'))
+
+    expect(
+      screen.getByRole('button', { name: /Get Contacts \(1\)/ })
+    ).toBeInTheDocument()
+  })
+
+  it('select all then clear round-trip updates the header', async () => {
+    renderList()
+    await waitForMembers()
+
+    // Click the first "Select all members" checkbox (mobile row)
+    const [selectAll] = screen.getAllByRole('checkbox', {
+      name: 'Select all members',
+    })
+    fireEvent.click(selectAll)
+
+    expect(
+      screen.getByRole('button', { name: /Get Contacts \(2\)/ })
+    ).toBeInTheDocument()
+
+    // Clear via the Clear button that appears when selection > 0
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+
+    expect(
+      screen.getByRole('button', { name: /^Get Contacts$/ })
+    ).toBeInTheDocument()
+  })
+
+  it('per-member get button downloads a vcf blob on non-iOS', async () => {
+    renderList()
+    await waitForMembers()
+
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+
+    // Jane is the non-owner row; use her button. There are two rows (mobile +
+    // desktop), click the first.
+    const getButtons = screen.getAllByRole('button', {
+      name: "Get Jane Smith's contact",
+    })
+    fireEvent.click(getButtons[0])
+
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('per-member get button uses a data URI on iOS', async () => {
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15'
+    )
+    renderList()
+    await waitForMembers()
+
+    // Intercept window.location assignments
+    const originalLocation = window.location
+    const hrefSpy = vi.fn()
+    // @ts-expect-error override for test
+    delete window.location
+    // @ts-expect-error override for test
+    window.location = {
+      ...originalLocation,
+      set href(value: string) {
+        hrefSpy(value)
+      },
+      get href() {
+        return originalLocation.href
+      },
+    }
+
+    try {
+      const getButtons = screen.getAllByRole('button', {
+        name: "Get Jane Smith's contact",
+      })
+      fireEvent.click(getButtons[0])
+
+      expect(hrefSpy).toHaveBeenCalled()
+      const arg = hrefSpy.mock.calls[0][0] as string
+      expect(arg.startsWith('data:text/x-vcard')).toBe(true)
+    } finally {
+      // @ts-expect-error restore
+      window.location = originalLocation
+    }
+  })
+
+  it('Get Contacts with a selection posts memberIds to the SMS API', async () => {
+    renderList()
+    await waitForMembers()
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    fireEvent.click(getRowCheckbox('Jane Smith'))
+    fireEvent.click(
+      screen.getByRole('button', { name: /Get Contacts \(1\)/ })
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.memberIds).toEqual(['2'])
+    expect(body.groupId).toBe('test-group')
+  })
+
+  it('Get Contacts with no selection omits memberIds', async () => {
+    renderList()
+    await waitForMembers()
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    fireEvent.click(screen.getByRole('button', { name: /^Get Contacts$/ }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect('memberIds' in body).toBe(false)
+  })
+
+  it('get button is visible for every member including the owner', async () => {
+    renderList()
+    await waitForMembers()
+
+    // Both John (owner) and Jane (non-owner) should have get-contact buttons
+    expect(
+      screen.getAllByRole('button', { name: "Get John Doe's contact" }).length
+    ).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getAllByRole('button', { name: "Get Jane Smith's contact" }).length
+    ).toBeGreaterThanOrEqual(1)
+    // And the owner-only trash button is still present for the non-owner row only
+    expect(
+      screen.getAllByRole('button', { name: /Remove Jane Smith from group/ })
+        .length
+    ).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.queryAllByRole('button', { name: /Remove John Doe from group/ })
+    ).toHaveLength(0)
   })
 })

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Trash2, Phone, Mail, Users, Smartphone, Share2, UserPlus, ChevronDown, Loader2, Download } from 'lucide-react'
+import { Trash2, Users, Smartphone, Share2, UserPlus, ChevronDown, Loader2, Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -536,10 +536,6 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                 )}
               </div>
             </div>
-            <div className="flex items-center gap-1.5 text-muted-foreground">
-              <Mail className="h-4 w-4" aria-label="Has email" />
-              {member.phone && <Phone className="h-4 w-4" aria-label="Has phone" />}
-            </div>
             <div className="flex items-center gap-1">
               <Button
                 variant="ghost"
@@ -585,7 +581,6 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
               />
             </TableHead>
             <TableHead>Member</TableHead>
-            <TableHead>Contact</TableHead>
             <TableHead className="w-[120px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
@@ -611,12 +606,6 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                       <Badge variant="secondary" className="text-xs">Owner</Badge>
                     )}
                   </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Mail className="h-4 w-4" aria-label="Has email" />
-                  {member.phone && <Phone className="h-4 w-4" aria-label="Has phone" />}
                 </div>
               </TableCell>
               <TableCell>

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Table,
   TableBody,
@@ -70,6 +71,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
 
   const [isExporting, setIsExporting] = useState(false)
   const [isSending, setIsSending] = useState(false)
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(new Set())
 
   const { data: members, isLoading, error } = useQuery<GroupMember[]>({
     queryKey: ['group-members', groupId],
@@ -86,10 +88,20 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
   const totalMembers = members?.length ?? 0
   const disableBulkActions = !members || members.length === 0
 
-  // Detect newly joined members for animation
+  // Detect newly joined members for animation + prune stale selections
   useEffect(() => {
     if (!members) return
     const currentIds = new Set(members.map(m => m.id))
+    // Drop any selected ids that no longer exist (member left, removed, etc.)
+    setSelectedMemberIds(prev => {
+      let shrunk = false
+      const next = new Set<string>()
+      for (const id of prev) {
+        if (currentIds.has(id)) next.add(id)
+        else shrunk = true
+      }
+      return shrunk ? next : prev
+    })
     if (isInitialLoadRef.current) {
       isInitialLoadRef.current = false
       knownMemberIdsRef.current = currentIds
@@ -229,6 +241,69 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     finally { setIsExporting(false) }
   }
 
+  // Selection helpers
+  const toggleMember = (id: string) => {
+    setSelectedMemberIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+  const selectionCount = selectedMemberIds.size
+  const allSelected = !!members && members.length > 0 && selectionCount === members.length
+  const toggleAll = () => {
+    if (!members) return
+    if (allSelected) {
+      setSelectedMemberIds(new Set())
+    } else {
+      setSelectedMemberIds(new Set(members.map(m => m.id)))
+    }
+  }
+  const clearSelection = () => setSelectedMemberIds(new Set())
+  const getSelectedMembers = () =>
+    (members ?? []).filter(m => selectedMemberIds.has(m.id))
+
+  // Export a single member's vCard. Synchronous on iOS — do NOT await before
+  // calling downloadViaDataUri or Safari will block the data: navigation.
+  const exportSingleContact = (member: GroupMember) => {
+    try {
+      const content = generateVCard(member)
+      if (isIOS) {
+        downloadViaDataUri(content)
+      } else {
+        downloadViaBlob(content, getSingleContactFilename(member))
+      }
+    } catch {
+      toast.error('Failed to export contact')
+    }
+  }
+
+  const exportSelectedContacts = async (via: 'share' | 'direct' | 'auto' = 'auto') => {
+    const selected = getSelectedMembers()
+    if (selected.length === 0) return toast.error('No members selected')
+    try {
+      setIsExporting(true)
+      const isSingle = selected.length === 1
+      const content = isSingle ? generateVCard(selected[0]) : generateBulkVCard(selected)
+      const filename = isSingle
+        ? getSingleContactFilename(selected[0])
+        : `${groupName.replace(/[^a-zA-Z0-9]/g, '_')}_selected_${selected.length}.vcf`
+      if (via === 'share') await downloadViaShare(content, filename)
+      else if (via === 'direct') downloadViaDataUri(content)
+      else downloadViaBlob(content, filename)
+      toast.success(
+        isSingle
+          ? `Contact exported: ${getDisplayName(selected[0])}`
+          : `${selected.length} contacts exported`
+      )
+    } catch {
+      toast.error('Failed to export contacts')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   const sendContactsViaSms = async () => {
     if (!profile?.phone) {
       toast.error('Add a phone number to your profile first', {
@@ -241,11 +316,17 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
       const res = await fetch('/api/sms/send-contacts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ to: profile.phone, groupId, groupName }),
+        body: JSON.stringify({
+          to: profile.phone,
+          groupId,
+          groupName,
+          ...(selectionCount > 0 ? { memberIds: Array.from(selectedMemberIds) } : {}),
+        }),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Failed to send')
       toast.success('Contacts sent! Check your messages.')
+      if (selectionCount > 0) clearSelection()
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to send contacts via SMS')
     } finally { setIsSending(false) }
@@ -274,7 +355,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                 className="rounded-r-none border-r-0"
               >
                 {isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Smartphone className="h-4 w-4" />}
-                Get Contacts
+                {selectionCount > 0 ? `Get Contacts (${selectionCount})` : 'Get Contacts'}
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -293,7 +374,25 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  {isIOS ? (
+                  {selectionCount > 0 ? (
+                    isIOS ? (
+                      <>
+                        <DropdownMenuItem onClick={() => exportSelectedContacts('direct')}>
+                          <UserPlus className="h-4 w-4" />
+                          Add Selected ({selectionCount})
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => exportSelectedContacts('share')}>
+                          <Share2 className="h-4 w-4" />
+                          Share Selected ({selectionCount})
+                        </DropdownMenuItem>
+                      </>
+                    ) : (
+                      <DropdownMenuItem onClick={() => exportSelectedContacts()}>
+                        <Download className="h-4 w-4" />
+                        Export Selected ({selectionCount})
+                      </DropdownMenuItem>
+                    )
+                  ) : isIOS ? (
                     <>
                       <DropdownMenuItem onClick={() => exportAllContacts('direct')}>
                         <UserPlus className="h-4 w-4" />
@@ -388,6 +487,29 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     )
   }
 
+  const selectAllRow = (
+    <div className="flex items-center justify-between px-1 md:hidden">
+      <label className="flex items-center gap-2 text-sm">
+        <Checkbox
+          checked={allSelected}
+          onCheckedChange={toggleAll}
+          aria-label="Select all members"
+        />
+        <span>Select all ({memberCount})</span>
+      </label>
+      {selectionCount > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearSelection}
+          className="h-auto px-2 py-1 text-xs"
+        >
+          Clear
+        </Button>
+      )}
+    </div>
+  )
+
   const mobileList = (
     <div className="flex flex-col gap-3 md:hidden">
       {members.map((member) => (
@@ -396,6 +518,12 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
           className={`rounded-lg border bg-card/50 p-3 shadow-sm${newMemberIds.has(member.id) ? ' animate-bubble-enter' : ''}`}
         >
           <div className="flex items-center gap-3">
+            <Checkbox
+              checked={selectedMemberIds.has(member.id)}
+              onCheckedChange={() => toggleMember(member.id)}
+              aria-label={`Select ${getDisplayName(member)}`}
+              className="shrink-0"
+            />
             <Avatar>
               {member.avatar_url && <AvatarImage src={member.avatar_url} alt={getDisplayName(member)} />}
               <AvatarFallback>{getInitials(member)}</AvatarFallback>
@@ -412,18 +540,32 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
               <Mail className="h-4 w-4" aria-label="Has email" />
               {member.phone && <Phone className="h-4 w-4" aria-label="Has phone" />}
             </div>
-            {isOwner && !member.is_owner && (
+            <div className="flex items-center gap-1">
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => handleRemoveMember(member)}
-                disabled={removeMemberMutation.isPending}
-                className="text-destructive hover:text-destructive"
-                aria-label={`Remove ${getDisplayName(member)} from group`}
+                onClick={() => exportSingleContact(member)}
+                aria-label={`Get ${getDisplayName(member)}'s contact`}
               >
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                {isIOS ? (
+                  <UserPlus className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Download className="h-4 w-4" aria-hidden="true" />
+                )}
               </Button>
-            )}
+              {isOwner && !member.is_owner && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemoveMember(member)}
+                  disabled={removeMemberMutation.isPending}
+                  className="text-destructive hover:text-destructive"
+                  aria-label={`Remove ${getDisplayName(member)} from group`}
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       ))}
@@ -435,14 +577,28 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-[40px]">
+              <Checkbox
+                checked={allSelected}
+                onCheckedChange={toggleAll}
+                aria-label="Select all members"
+              />
+            </TableHead>
             <TableHead>Member</TableHead>
             <TableHead>Contact</TableHead>
-            {isOwner && <TableHead className="w-[100px]">Actions</TableHead>}
+            <TableHead className="w-[120px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {members.map((member) => (
             <TableRow key={member.id} className={newMemberIds.has(member.id) ? 'animate-bubble-enter' : ''}>
+              <TableCell className="w-[40px]">
+                <Checkbox
+                  checked={selectedMemberIds.has(member.id)}
+                  onCheckedChange={() => toggleMember(member.id)}
+                  aria-label={`Select ${getDisplayName(member)}`}
+                />
+              </TableCell>
               <TableCell>
                 <div className="flex items-center space-x-3">
                   <Avatar>
@@ -463,9 +619,21 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                   {member.phone && <Phone className="h-4 w-4" aria-label="Has phone" />}
                 </div>
               </TableCell>
-              {isOwner && (
-                <TableCell>
-                  {!member.is_owner && (
+              <TableCell>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => exportSingleContact(member)}
+                    aria-label={`Get ${getDisplayName(member)}'s contact`}
+                  >
+                    {isIOS ? (
+                      <UserPlus className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <Download className="h-4 w-4" aria-hidden="true" />
+                    )}
+                  </Button>
+                  {isOwner && !member.is_owner && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -477,8 +645,8 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
                       <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </Button>
                   )}
-                </TableCell>
-              )}
+                </div>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -490,6 +658,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     <Card>
       <CardHeader>{headerContent}</CardHeader>
       <CardContent className="space-y-4">
+        {selectAllRow}
         {mobileList}
         {table}
       </CardContent>
@@ -497,6 +666,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
   ) : (
     <div className="space-y-4">
       {headerContent}
+      {selectAllRow}
       {mobileList}
       {table}
     </div>


### PR DESCRIPTION
## Summary
This PR adds member selection capabilities and per-member contact export functionality to the MemberList component, allowing users to select individual members or all members at once and export their contacts via vCard format.

## Key Changes

- **Multi-select UI**: Added checkboxes for individual member selection and a "Select all" checkbox in both mobile and desktop layouts, with a "Clear" button that appears when members are selected
- **Per-member contact export**: Added individual "Get Contact" buttons for each member (visible for all members, including owners) that export a single member's vCard
- **Selection count display**: Updated the "Get Contacts" button to display the count of selected members when any are selected
- **Selective SMS export**: Modified the SMS send-contacts API to accept an optional `memberIds` parameter, allowing users to send contacts for only selected members instead of the entire group
- **Selection state management**: Implemented selection state tracking with automatic pruning of stale selections when members leave or are removed
- **Platform-specific export**: Maintained existing iOS vs. non-iOS export behavior (data URI vs. blob download) for both bulk and single-member exports
- **API validation**: Added server-side validation to ensure that when `memberIds` is provided, it contains at least one valid ID to prevent accidental "send all" fallbacks

## Implementation Details

- Selection state is stored in a `Set<string>` for efficient membership checks
- The "Select all" checkbox state is derived from comparing selection count to total members
- Stale selections are automatically cleaned up when the member list updates via a `useEffect` hook
- The SMS API endpoint filters members by both group ID and the provided member IDs, preventing cross-group ID injection
- Both mobile (card-based) and desktop (table) layouts support the same selection and export functionality
- Comprehensive test coverage added for selection behavior, export methods, and API integration

https://claude.ai/code/session_01MiEVHYXPuo7paJ5VLpXVjd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member multi-selection in group member lists with “select all” and “Clear”.
  * Export/download contacts for individual members or selected members; iOS-specific export handled.
  * SMS sending can target selected members (selection clears after successful send).
  * Selection auto-syncs with refreshed member lists.

* **Tests**
  * Expanded tests covering selection UI, per-member and bulk contact export, platform download paths, and SMS-send payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->