### PR TITLE
fix: use generateMemberVCard in member-list export helpers

### DIFF
--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/lib/database'
 import { toast } from 'sonner'
 import { getDisplayName, getInitials, extractNames } from '@/lib/name-utils'
-import { generateBulkVCard } from '@/lib/vcard'
+import { generateBulkVCard, generateMemberVCard } from '@/lib/vcard'
 import { useAuth } from '@/hooks/use-auth'
 
 interface GroupMember {
@@ -236,7 +236,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
   // calling downloadViaDataUri or Safari will block the data: navigation.
   const exportSingleContact = (member: GroupMember) => {
     try {
-      const content = generateVCard(member)
+      const content = generateMemberVCard(member, groupName)
       if (isIOS) {
         downloadViaDataUri(content)
       } else {
@@ -253,7 +253,9 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     try {
       setIsExporting(true)
       const isSingle = selected.length === 1
-      const content = isSingle ? generateVCard(selected[0]) : generateBulkVCard(selected)
+      const content = isSingle
+        ? generateMemberVCard(selected[0], groupName)
+        : generateBulkVCard(selected, groupName)
       const filename = isSingle
         ? getSingleContactFilename(selected[0])
         : `${groupName.replace(/[^a-zA-Z0-9]/g, '_')}_selected_${selected.length}.vcf`


### PR DESCRIPTION
The per-member and multi-select export paths in MemberList referenced
an undefined `generateVCard` helper, breaking the Vercel build with
`Cannot find name 'generateVCard'`. `@/lib/vcard` exports
`generateMemberVCard` (requiring a groupName for the ORG/NOTE lines)
and `generateBulkVCard` (also groupName-bearing), so switch the single
and selected-export paths to call `generateMemberVCard(member, groupName)`
and pass `groupName` to `generateBulkVCard` for the selected-bulk case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contact export functionality to properly include group information when exporting individual or bulk contacts in vCard format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->