### PR TITLE
Clarify SMS/MMS messaging and update consent flow

### DIFF
--- a/src/app/onboarding/phone/page.tsx
+++ b/src/app/onboarding/phone/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Loader2 } from 'lucide-react'
@@ -72,6 +73,17 @@ export default function OnboardingPhonePage() {
             )}
           </div>
 
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            By continuing, you agree to our{' '}
+            <Link href="/terms" className="underline hover:text-primary">Terms of Service</Link>{' '}
+            and{' '}
+            <Link href="/privacy" className="underline hover:text-primary">Privacy Policy</Link>
+            , and consent to receive text messages from Bubbles &mdash; including verification
+            codes and, if you opt in from your profile, MMS contact cards from groups you join.
+            Msg frequency varies. Msg &amp; data rates may apply. Reply STOP to opt out, HELP for
+            help.
+          </p>
+
           <Button
             type="submit"
             className="w-full"
@@ -82,10 +94,6 @@ export default function OnboardingPhonePage() {
             Continue with phone
           </Button>
         </form>
-
-        <p className="mt-6 text-center text-xs text-muted-foreground">
-          We&rsquo;ll send you a verification code via SMS
-        </p>
       </main>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,6 +70,46 @@ export default async function Home() {
           </div>
         </footer>
       </main>
+
+      <section
+        id="sms-program"
+        aria-labelledby="sms-program-heading"
+        className="border-t border-border bg-[var(--surface)]"
+      >
+        <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 sm:py-16">
+          <p className="font-label mb-2 text-xs uppercase tracking-widest text-muted-foreground">
+            SMS program
+          </p>
+          <h2 id="sms-program-heading" className="font-display text-2xl font-bold sm:text-3xl">
+            Texts from Bubbles
+          </h2>
+          <p className="mt-4 text-base leading-relaxed text-foreground/80">
+            Bubbles sends two kinds of messages from a verified toll-free number:
+          </p>
+          <ul className="mt-4 space-y-3 text-base leading-relaxed text-foreground/80">
+            <li>
+              <strong className="text-foreground">Account verification (SMS).</strong>{' '}
+              One-time codes when you sign in or confirm your phone number. Required to use the
+              product.
+            </li>
+            <li>
+              <strong className="text-foreground">Contact cards (MMS).</strong> When a group you
+              joined shares its contacts, you receive an MMS with a vCard you can save to your
+              phone. Opt-in, off by default.
+            </li>
+          </ul>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Opt in at signup or from your profile. Reply <strong className="text-foreground">STOP</strong>{' '}
+            to any message to opt out, or <strong className="text-foreground">HELP</strong> for
+            support. Msg frequency varies; msg &amp; data rates may apply. See our{' '}
+            <Link href="/terms" className="text-primary hover:underline">Terms of Service</Link>{' '}
+            and{' '}
+            <Link href="/privacy" className="text-primary hover:underline">Privacy Policy</Link>{' '}
+            for full details.
+          </p>
+        </div>
+      </section>
+
       <AuthRedirect mmsOnboarding={isMmsOnboarding} />
     </div>
   )

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -262,18 +262,30 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
                 className="mt-0.5"
               />
               <label htmlFor="sms_notifications_enabled" className="cursor-pointer space-y-1">
-                <p className="text-sm font-medium leading-none">Receive group updates by text</p>
+                <p className="text-sm font-medium leading-none">Send contact cards by MMS when I join a group</p>
                 <p className="text-xs text-muted-foreground">
-                  Bubbles will text you group updates. You can opt-out at any time.
+                  Optional. You can change this anytime in your profile.
                 </p>
               </label>
             </div>
           )}
 
+          {isSignUp && (
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              By creating an account, you agree to our{' '}
+              <Link href="/terms" className="underline hover:text-primary">Terms of Service</Link>{' '}
+              and{' '}
+              <Link href="/privacy" className="underline hover:text-primary">Privacy Policy</Link>
+              , and consent to receive text messages from Bubbles &mdash; including verification
+              codes and, if enabled above, MMS contact cards from groups you join. Msg frequency
+              varies. Msg &amp; data rates may apply. Reply STOP to opt out, HELP for help.
+            </p>
+          )}
+
           <Button
             type="submit"
             className="w-full"
-            disabled={isLoading || isGoogleLoading || (isSignUp && !smsOptIn)}
+            disabled={isLoading || isGoogleLoading}
           >
             {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" data-testid="loading-spinner" />}
             {isSignUp ? 'Create Account' : 'Sign In'}
@@ -293,15 +305,6 @@ export function AuthForm({ mode = 'signin', onSuccess, redirectTo }: AuthFormPro
             </button>
           </p>
         </div>
-
-        {isSignUp && (
-          <div className="mt-4 text-xs text-muted-foreground text-center">
-            By creating an account, you agree to our{' '}
-            <Link href="/terms" className="underline hover:text-primary">Terms of Service</Link>{' '}
-            and{' '}
-            <Link href="/privacy" className="underline hover:text-primary">Privacy Policy</Link>
-          </div>
-        )}
       </CardContent>
     </Card>
   )

--- a/src/components/auth/profile-form.tsx
+++ b/src/components/auth/profile-form.tsx
@@ -336,7 +336,7 @@ export function ProfileForm({ onSuccess }: ProfileFormProps) {
             <div className="space-y-1">
               <p className="text-sm font-medium">SMS notifications</p>
               <p className="text-xs text-muted-foreground">
-                Receive important updates and group changes via text message.
+                Receive MMS contact cards from groups you join. Reply STOP to opt out.
               </p>
             </div>
             <Switch

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -29,7 +29,10 @@ import {
 } from '@/lib/database'
 import { toast } from 'sonner'
 import { getDisplayName, getInitials, extractNames } from '@/lib/name-utils'
-import { generateBulkVCard } from '@/lib/vcard'
+import {
+  generateMemberVCard,
+  generateBulkVCard as generateBulkVCardBase,
+} from '@/lib/vcard'
 import { useAuth } from '@/hooks/use-auth'
 
 interface GroupMember {
@@ -78,6 +81,12 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
   const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/i.test(navigator.userAgent)
   const totalMembers = members?.length ?? 0
   const disableBulkActions = !members || members.length === 0
+
+  const generateVCard = (member: GroupMember): string =>
+    generateMemberVCard(member, groupName)
+
+  const generateBulkVCard = (memberList: GroupMember[]): string =>
+    generateBulkVCardBase(memberList, groupName)
 
   // Detect newly joined members for animation + prune stale selections
   useEffect(() => {
@@ -199,7 +208,7 @@ export function MemberList({ groupId, groupName, isOwner, layout = 'card' }: Mem
     if (!members || members.length === 0) return toast.error('No members to export')
     try {
       setIsExporting(true)
-      const content = generateBulkVCard(members, groupName)
+      const content = generateBulkVCard(members)
       const filename = `${groupName.replace(/[^a-zA-Z0-9]/g, '_')}_all_contacts.vcf`
       if (via === 'share') await downloadViaShare(content, filename)
       else if (via === 'direct') downloadViaDataUri(content)


### PR DESCRIPTION
## Summary
This PR updates the messaging and consent flow around SMS/MMS communications to be more transparent and accurate about what messages users will receive. It distinguishes between required account verification SMS and optional MMS contact cards, and updates the signup consent language accordingly.

## Key Changes
- **New SMS program section**: Added a dedicated informational section on the home page explaining the two types of messages Bubbles sends:
  - Account verification SMS (required)
  - Contact card MMS (opt-in, off by default)
  - Includes opt-out instructions (STOP/HELP) and legal disclaimers

- **Updated signup form messaging**:
  - Changed SMS notification checkbox label from "Receive group updates by text" to "Send contact cards by MMS when I join a group" for clarity
  - Updated helper text to indicate this is optional and changeable in profile
  - Removed the requirement to opt-in to SMS to create an account (removed `smsOptIn` from submit button disabled state)
  - Expanded consent text to explicitly mention both verification codes and optional MMS contact cards

- **Updated profile form messaging**:
  - Changed SMS notifications description from "Receive important updates and group changes via text message" to "Receive MMS contact cards from groups you join. Reply STOP to opt out."
  - Better reflects the actual functionality and opt-out mechanism

## Implementation Details
- The new SMS program section uses semantic HTML with proper ARIA labels for accessibility
- Consent language now clearly distinguishes between required verification SMS and optional MMS
- Removed the artificial requirement to opt-in to SMS during signup, making the feature truly optional
- Consistent messaging across signup, profile, and informational sections

https://claude.ai/code/session_01PKKuvqhseZ89uj5jVSeF59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "SMS program" section on the Home page describing account verification and optional MMS contact-card sharing, with links to Terms and Privacy.

* **Improvements**
  * Clarified SMS/MMS opt-in and consent text across sign-up, phone verification, and profile screens; consent now appears inline with Terms and Privacy links and STOP/HELP guidance.
  * Sign-up no longer requires SMS opt-in to submit.
  * Improved single and bulk contact export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->