### PR TITLE
feat: label QR style toggle with QrCode icon

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -8,7 +8,6 @@ import { ArrowLeft, Bug, LogOut, QrCode, Settings } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -114,13 +113,10 @@ export function AppHeader() {
               Settings
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuCheckboxItem
-              checked={classicCards}
-              onCheckedChange={handleClassicCardsToggle}
-            >
-              <QrCode className="size-4 text-muted-foreground" />
+            <DropdownMenuItem onSelect={() => handleClassicCardsToggle(!classicCards)}>
+              <QrCode className="size-4" />
               Switch QR Style
-            </DropdownMenuCheckboxItem>
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={() => setBugSheetOpen(true)}>
               <Bug className="size-4" />

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
-import { ArrowLeft, Bug, LogOut, Settings } from 'lucide-react'
+import { ArrowLeft, Bug, LogOut, QrCode, Settings } from 'lucide-react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -118,7 +118,8 @@ export function AppHeader() {
               checked={classicCards}
               onCheckedChange={handleClassicCardsToggle}
             >
-              Classic Cards
+              <QrCode className="size-4 text-muted-foreground" />
+              Switch QR Style
             </DropdownMenuCheckboxItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={() => setBugSheetOpen(true)}>


### PR DESCRIPTION
Renames the "Classic Cards" item in the header dropdown to **Switch QR Style** and gives it lucide's `QrCode` glyph.

The rename is the more accurate label: the `classic-cards` cookie is read in `src/app/(app)/group/[token]/page.tsx:21-22` and only decides whether the group page renders the flat QR card or the QR cube. It never controlled contact cards.

```tsx
<DropdownMenuCheckboxItem checked={classicCards} onCheckedChange={handleClassicCardsToggle}>
  <QrCode className="size-4 text-muted-foreground" />
  Switch QR Style
</DropdownMenuCheckboxItem>
```

### Notes for review

- **The icon needs the explicit `text-muted-foreground`.** `DropdownMenuItem` mutes its svgs via a descendant rule (`dropdown-menu.tsx:77`); `DropdownMenuCheckboxItem` has no equivalent, so without it the glyph renders at full text color and reads heavier than Settings / Report a Bug / Sign Out.
- **Indent is one step right of its neighbours.** As a checkbox item its content starts at `pl-8` to clear the checkmark gutter, so the QR icon sits in the column where the other items' text begins — a macOS-style check-gutter-then-icon layout. If you'd rather have all four icons share one column, the alternative is a plain `DropdownMenuItem` with the current style shown as trailing text instead of a checkmark. Happy to switch.
- `QrCode` was picked over `ScanQrCode` / `ScanLine` because it reads as "a QR code" rather than "scanning one" — this item switches how your own code is displayed. Stroke stays at lucide's default 2 to match the rest of the menu.

### Testing

- `app-header.test.tsx` passes (8/8).
- The wider suite has 46 failures across 5 files, but they reproduce identically on a clean tree — pre-existing, untouched by this diff. `tsc` and `eslint` errors are likewise all pre-existing (test-file typing, plus a `parserOptions.project` parse error in `.well-known/vercel/flags/route.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhEndacwvK5yPFqyEnVejX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhEndacwvK5yPFqyEnVejX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the card-style toggle with a QR-code icon.
  * Renamed the toggle label to “Switch QR Style.”
  * Preserved the existing toggle behavior for switching card styles.
  * Improved visual clarity and consistency in the app header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->